### PR TITLE
ActionSequencesAddWithTarget accidentally added the wrong action

### DIFF
--- a/Core/Location/Location.cs
+++ b/Core/Location/Location.cs
@@ -312,9 +312,9 @@ namespace OpenTemple.Core.Location
             return FromInches(pos.X, pos.Z);
         }
 
-        /**
-         * Distance between this location and the other location in inches.
-         */
+        /// <summary>
+        /// Distance between this location and the other location in inches.
+        /// </summary>
         [TempleDllLocation(0x1002A0A0)]
         [TempleDllLocation(0x10040010)] /* The pointer based version */
         public float DistanceTo(LocAndOffsets locB)

--- a/Core/Systems/D20/Actions/D20ActionSystem.cs
+++ b/Core/Systems/D20/Actions/D20ActionSystem.cs
@@ -131,7 +131,7 @@ namespace OpenTemple.Core.Systems.D20.Actions
         private ActionSequence? actSeqInterrupt;
 
         [TempleDllLocation(0x1186A8F0)]
-        internal ActionSequence CurrentSequence { get; set; }
+        internal ActionSequence? CurrentSequence { get; set; }
 
         [TempleDllLocation(0x1008a090)]
         internal D20Action CurrentAction

--- a/Core/Systems/ScrollSystem.cs
+++ b/Core/Systems/ScrollSystem.cs
@@ -127,6 +127,7 @@ namespace OpenTemple.Core.Systems
             {
                 _mapScrollX = 0;
                 _mapScrollY = 0;
+                _screenCenterTile = new locXY(tileX, tileY);
             }
         }
 

--- a/Core/TigSubsystems/HeadlessMainWindow.cs
+++ b/Core/TigSubsystems/HeadlessMainWindow.cs
@@ -26,9 +26,10 @@ namespace OpenTemple.Core.TigSubsystems
             Closed?.Invoke();
         }
 
-        public SizeF UiCanvasSize => new (OffScreenSize.Width, OffScreenSize.Height);
+        public SizeF UiCanvasSize => new(OffScreenSize.Width, OffScreenSize.Height);
 
         public event Action UiCanvasSizeChanged;
+
         public float UiScale { get; set; } = 1.0f;
 
         public void SetCursor(int hotspotX, int hotspotY, string imagePath)
@@ -36,8 +37,14 @@ namespace OpenTemple.Core.TigSubsystems
         }
 
         public bool IsCursorVisible { get; set; }
+
         public void Dispose()
         {
+        }
+
+        public void SendInput(WindowEvent obj)
+        {
+            OnInput?.Invoke(obj);
         }
     }
 }

--- a/Core/Ui/UiManager.cs
+++ b/Core/Ui/UiManager.cs
@@ -666,6 +666,12 @@ namespace OpenTemple.Core.Ui
 
         private void HandleMouseButtonEvent(MouseWindowEvent evt)
         {
+            // Otherwise we might not get the actual position that was clicked if we use the last mouse move position..
+            if (evt.Type == WindowEventType.MouseDown)
+            {
+                HandleMouseMoveEvent(evt);
+            }
+
             Tig.Mouse.SetButtonState(evt.Button, evt.Type == WindowEventType.MouseDown);
         }
 

--- a/Launcher.Win/Launcher.cs
+++ b/Launcher.Win/Launcher.cs
@@ -19,7 +19,7 @@ namespace OpenTemple.Windows
             // When a debugger is attached, immediately rethrow unobserved exceptions from asynchronous tasks
             if (Debugger.IsAttached)
             {
-                TaskScheduler.UnobservedTaskException += (sender, eventArgs) =>
+                TaskScheduler.UnobservedTaskException += (_, eventArgs) =>
                 {
                     if (!eventArgs.Observed)
                     {

--- a/Tests/Game/D20ActionSystemTests.cs
+++ b/Tests/Game/D20ActionSystemTests.cs
@@ -1,11 +1,14 @@
+using System;
 using System.Linq;
 using FluentAssertions;
 using NUnit.Framework;
+using OpenTemple.Core;
 using OpenTemple.Core.GameObject;
 using OpenTemple.Core.Location;
 using OpenTemple.Core.Systems;
 using OpenTemple.Core.Systems.D20;
 using OpenTemple.Core.Systems.D20.Actions;
+using OpenTemple.Core.Ui;
 using OpenTemple.Tests.TestUtils;
 
 namespace OpenTemple.Tests.Game
@@ -27,7 +30,11 @@ namespace OpenTemple.Tests.Game
         private GameObjectBody Create(int protoId)
         {
             var obj = GameSystems.MapObject.CreateObject(protoId, new locXY(500, 483));
-            GameSystems.Critter.GenerateHp(obj);
+            if (obj.IsCritter())
+            {
+                GameSystems.Critter.GenerateHp(obj);
+            }
+
             return obj;
         }
 
@@ -46,7 +53,63 @@ namespace OpenTemple.Tests.Game
             var action = new D20Action(D20ActionType.STANDARD_ATTACK, giantRat);
             var tbStatus = new TurnBasedStatus();
 
-            GameSystems.D20.Actions.D20ActionTriggersAoO(action,tbStatus).Should().BeFalse();
+            GameSystems.D20.Actions.D20ActionTriggersAoO(action, tbStatus).Should().BeFalse();
+        }
+
+        /// <summary>
+        /// Tests that the lockpicking action is performed after moving into range, when clicking on the locked
+        /// chest from afar.
+        /// </summary>
+        [Test]
+        [RecordFailureVideo]
+        public void ActionsArePerformedAfterMovingIntoRange()
+        {
+            // Spawn a player and a chest (at a distance), and click on the chest
+            var player = CreatePlayer();
+            var lockedChest = Create(TestProtos.LockedChest);
+            ClickOn(lockedChest);
+
+            // This should make the party leader perform the default action,
+            // which is to open the container.
+            Game.RunUntil(() => GameSystems.D20.Actions.IsCurrentlyPerforming(player));
+
+            var sequence = GameSystems.D20.Actions.CurrentSequence ?? throw new NullReferenceException();
+            sequence.performer.Should().Be(player);
+            sequence.targetObj.Should().Be(lockedChest);
+
+            // Run until the sequence has concluded
+            Game.RunUntil(() => !GameSystems.D20.Actions.IsCurrentlyPerforming(player), 5000);
+
+            // Since the player was not in reach, there should be a move action performed,
+            // then the opening action
+            CompletedActions.Should().SatisfyRespectively(
+                first =>
+                {
+                    first.d20APerformer.Should().Be(player);
+                    first.d20ActType.Should().Be(D20ActionType.MOVE);
+                    // The target location should bring the player into reach of the container
+                    first.destLoc.DistanceTo(lockedChest.GetLocationFull()).Should().BeLessOrEqualTo(
+                        player.GetRadius()
+                        + lockedChest.GetRadius()
+                        // Reach returns feet
+                        + player.GetReach(D20ActionType.OPEN_CONTAINER) * locXY.INCH_PER_FEET
+                    );
+                },
+                second =>
+                {
+                    second.d20ActType.Should().Be(D20ActionType.OPEN_CONTAINER);
+                    second.d20APerformer.Should().Be(player);
+                    second.d20ATarget.Should().Be(lockedChest);
+                }
+            );
+        }
+
+        private GameObjectBody CreatePlayer(int x = 500, int y = 477)
+        {
+            var player = GameSystems.MapObject.CreateObject(TestProtos.HumanMalePlayer, new locXY(x, y));
+            GameSystems.Party.AddToPCGroup(player);
+            Game.RenderFrame(); // Have to render once to uncover fog of war
+            return player;
         }
     }
 }

--- a/Tests/Game/TestProtos.cs
+++ b/Tests/Game/TestProtos.cs
@@ -6,5 +6,6 @@ namespace OpenTemple.Tests.Game
         public const int Zombie = 14092;
         public const int GiantRat = 14433;
         public const int HumanMalePlayer = 13000;
+        public const int LockedChest = 1048;
     }
 }

--- a/Tests/TestUtils/HeadlessGameTest.cs
+++ b/Tests/TestUtils/HeadlessGameTest.cs
@@ -4,13 +4,17 @@ using System.Diagnostics;
 using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Text;
+using Microsoft.CodeAnalysis;
 using NUnit.Framework;
+using OpenTemple.Core;
 using OpenTemple.Core.GameObject;
+using OpenTemple.Core.Platform;
 using OpenTemple.Core.Systems;
 using OpenTemple.Core.Systems.D20;
 using OpenTemple.Core.Systems.D20.Actions;
 using OpenTemple.Core.Systems.RollHistory;
 using OpenTemple.Core.Time;
+using OpenTemple.Core.Ui;
 using OpenTemple.Core.Utils;
 using SixLabors.ImageSharp;
 
@@ -113,6 +117,12 @@ namespace OpenTemple.Tests.TestUtils
             Game.RenderFrame();
             var screenshot = Game.TakeScreenshot();
             screenshot.SaveAsPng(TestContext.CurrentContext.Test.FullName + "_" + name + ".png");
+        }
+
+        protected void ClickOn(GameObjectBody obj)
+        {
+            var pos = GameSystems.MapObject.GetScreenPosOfObject(GameViews.Primary, obj);
+            Game.ClickUi(pos.X, pos.Y);
         }
     }
 }


### PR DESCRIPTION
Fixes #55 

@DudeMcDude Can you take a look at this? I modeled this after the T+ code now.
The root cause was just adding the UNSPECIFIED_MODE action-copy instead of the actual action, but I refactored it a bit.

The juicy bit: https://github.com/GrognardsFromHell/OpenTemple/pull/56/files#diff-f72e52ea3af61bebf6990a9e29130e1fad228b6ccfb1f4bea918d5f2b089abd5R2278

I removed the old code setting a result on the copied TB status. That should be okay, right?

Also: Added a nice test for this 😁 
